### PR TITLE
Sphe/feat/rds connection fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
           cat > ./server/.env <<EOF
           DB_USER=${{ env.CREDENTIALS_USERNAME }}
           DB_HOST=${{ env.CREDENTIALS_HOST }}
-          DB_NAME=${{ secrets.DB_NAME }}
+          DB_NAME=${{ env.CREDENTIALS_DB_NAME }}
           DB_PORT=${{ env.CREDENTIALS_PORT }}
           DB_PASSWORD=${{ env.CREDENTIALS_PASSWORD }}
           AWS_CLIENT_ID=${{ secrets.AWS_CLIENT_ID}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,6 @@ jobs:
           AWS_CLIENT_ID=${{ secrets.AWS_CLIENT_ID}}
           AWS_CLIENT_SECRET=${{ secrets.AWS_CLIENT_SECRET }}
           AWS_USER_POOL_ID=${{ secrets.AWS_USER_POOL_ID }}
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }}
           EOF
       
       - name: Node setup

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -1,16 +1,17 @@
 name: Database Migration with Flyway
 
 on:
-  # TODO: uncomment these when we have the secrets in the repo
-  # push:
-  #   branches: 
-  #     - "main"
-  #     - "arinaho/feature/database-migrations"
-  #   paths:
-  #     - 'database/scripts/**'
-  #     - 'database/flyway/**'
+  push:
+    branches: [sphe/feat/rds-connection-fix]
+    paths:
+      - 'database/scripts/**'
+      - 'database/flyway/**'
 
   workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   migrate-database:
@@ -18,17 +19,46 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Generate flyway config file
-      run: |
-        echo "flyway.url=${{ secrets.DB_URL }}" >> flyway.generated.conf
-        echo "flyway.user=${{ secrets.DB_USER }}" >> flyway.generated.conf
-        echo "flyway.password=${{ secrets.DB_USER_PASSWORD }}" >> flyway.generated.conf
-        cat database/flyway/flyway.conf >> flyway.generated.conf
+      - name: Assume the deploy pipeline user role
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.ASSUME_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ secrets.AWS_REGION }}
 
-    - name: Run Flyway Migration
-      run: |
-        sudo snap install flyway
-        flyway migrate -configFiles=flyway.generated.conf
+      - name: Get private key secret
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            private_key
+            credentials
+          parse-json-secrets: true
+
+      - name: Store ssh key in pem file
+        run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+      
+      - name: Configure ssh tunnel through bastion host
+        run: |
+          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
+          PID=$!
+          echo "SSH_PID=$(echo $PID)" >> $GITHUB_ENV
+
+      - name: Generate flyway config file
+        run: |
+          cat > flyway.generated.conf <<EOF
+          flyway.url=jdbc:postgresql://localhost:5432/${{ env.CREDENTIALS_DB_NAME }}
+          flyway.user=${{ env.CREDENTIALS_USERNAME }}
+          flyway.password=${{ env.CREDENTIALS_PASSWORD }}
+          EOF
+          cat database/flyway/flyway.conf >> flyway.generated.conf
+
+      - name: Run Flyway Migration
+        run: |
+          sudo snap install flyway
+          flyway migrate -configFiles=flyway.generated.conf
+      
+      - name: Terminate SSH tunnel
+        run: kill -9 $SSH_PID

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -37,12 +37,16 @@ jobs:
             credentials
           parse-json-secrets: true
 
-      - name: Store ssh key in pem file
-        run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+      # - name: Store ssh key in pem file
+      #   run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
       
       - name: Configure ssh tunnel through bastion host
         run: |
-          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
+          mkdir ~/.ssh
+          ssh-keyscan -H ${{ secrets.BASTION_HOST }} >> ~/.ssh/known_hosts
+          eval `ssh-agent -s`
+          ssh-add - <<< "${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }}"
+          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} &
           PID=$!
           echo "SSH_PID=$(echo $PID)" >> $GITHUB_ENV
 

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -33,13 +33,12 @@ jobs:
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            private_key
             credentials
           parse-json-secrets: true
 
-      - name: Store ssh key in pem file
+      - name: Copy ssh key and modify permissios
         run: |
-          echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+          aws s3 cp s3://great-notes-state-bucket/ssh_key.pem .
           chmod 600 ssh_key.pem
 
       - name: Configure ssh tunnel through bastion host

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -2,7 +2,7 @@ name: Database Migration with Flyway
 
 on:
   push:
-    branches: 
+    branches:
       - sphe/feat/rds-connection-fix
     paths:
       - 'database/scripts/**'
@@ -37,16 +37,15 @@ jobs:
             credentials
           parse-json-secrets: true
 
-      # - name: Store ssh key in pem file
-      #   run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
-      
+      - name: Store ssh key in pem file
+        run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+
       - name: Configure ssh tunnel through bastion host
         run: |
           mkdir ~/.ssh
           ssh-keyscan -H ${{ secrets.BASTION_HOST }} >> ~/.ssh/known_hosts
           eval `ssh-agent -s`
-          ssh-add - <<< "${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }}"
-          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} &
+          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
           PID=$!
           echo "SSH_PID=$(echo $PID)" >> $GITHUB_ENV
 
@@ -63,6 +62,6 @@ jobs:
         run: |
           sudo snap install flyway
           flyway migrate -configFiles=flyway.generated.conf
-      
+
       - name: Terminate SSH tunnel
         run: kill -9 $SSH_PID

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -38,7 +38,9 @@ jobs:
           parse-json-secrets: true
 
       - name: Store ssh key in pem file
-        run: echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+        run: |
+          echo ${{ env.PRIVATE_KEY_PRIVATE_KEY_RFC1421 }} > ssh_key.pem
+          chmod 600 ssh_key.pem
 
       - name: Configure ssh tunnel through bastion host
         run: |

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'database/scripts/**'
       - 'database/flyway/**'
+      - '.github/workflows/flyway-migrations.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -3,7 +3,7 @@ name: Database Migration with Flyway
 on:
   push:
     branches:
-      - sphe/feat/rds-connection-fix
+      - main
     paths:
       - 'database/scripts/**'
       - 'database/flyway/**'

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir ~/.ssh
           ssh-keyscan -H ${{ secrets.BASTION_HOST }} >> ~/.ssh/known_hosts
           eval `ssh-agent -s`
-          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
+          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }}:5432 ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
 
       - name: Generate flyway config file
         run: |

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -2,7 +2,7 @@ name: Database Migration with Flyway
 
 on:
   push:
-    branches: [sphe/feat/rds-connection-fix]
+    branches: ["sphe/feat/rds-connection-fix"]
     paths:
       - 'database/scripts/**'
       - 'database/flyway/**'

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -47,8 +47,6 @@ jobs:
           ssh-keyscan -H ${{ secrets.BASTION_HOST }} >> ~/.ssh/known_hosts
           eval `ssh-agent -s`
           ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }} ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
-          PID=$!
-          echo "SSH_PID=$(echo $PID)" >> $GITHUB_ENV
 
       - name: Generate flyway config file
         run: |
@@ -63,6 +61,3 @@ jobs:
         run: |
           sudo snap install flyway
           flyway migrate -configFiles=flyway.generated.conf
-
-      - name: Terminate SSH tunnel
-        run: kill -9 $SSH_PID

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -2,12 +2,11 @@ name: Database Migration with Flyway
 
 on:
   push:
-    branches: ["sphe/feat/rds-connection-fix"]
+    branches: 
+      - sphe/feat/rds-connection-fix
     paths:
       - 'database/scripts/**'
       - 'database/flyway/**'
-
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/flyway-migrations.yml
+++ b/.github/workflows/flyway-migrations.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir ~/.ssh
           ssh-keyscan -H ${{ secrets.BASTION_HOST }} >> ~/.ssh/known_hosts
           eval `ssh-agent -s`
-          ssh -fN -v -L 5432:${{ env.CREDENTIALS_HOST }}:5432 ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
+          ssh -fN -v -L 127.0.0.1:5432:${{ env.CREDENTIALS_HOST }}:5432 ${{ secrets.BASTION_USER }}@${{ secrets.BASTION_HOST }} -i ssh_key.pem &
 
       - name: Generate flyway config file
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ role_config
 .env
 .secrets
 .terraform/.terraform
+*.pem

--- a/.terraform/autoscaling_group.tf
+++ b/.terraform/autoscaling_group.tf
@@ -1,0 +1,21 @@
+resource "aws_launch_configuration" "default" {
+  name_prefix     = "aws-asg-"
+  image_id        = "ami-0e9947f83884eae81"
+  instance_type   = "t2.micro"
+  security_groups = [aws_security_group.ebs_allow_tcp.id, aws_security_group.db_allow_tcp.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "default" {
+  min_size             = 1
+  max_size             = 1
+  desired_capacity     = 1
+  launch_configuration = aws_launch_configuration.default.name
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/.terraform/bastion_host.tf
+++ b/.terraform/bastion_host.tf
@@ -20,7 +20,7 @@ resource "aws_security_group" "allow_ssh" {
   vpc_id      = aws_vpc.default_vpc.id
 
   ingress {
-    description = "Allow all SSH traffic"
+    description = "Allow all traffic"
     from_port   = "22"
     to_port     = "22"
     protocol    = "tcp"
@@ -28,11 +28,33 @@ resource "aws_security_group" "allow_ssh" {
   }
 
   egress {
-    description = "Allow all SSH traffic"
+    description = "Allow all traffic"
     from_port   = "22"
     to_port     = "22"
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "allow_db" {
+  name        = "allow_db"
+  description = "Allow traffic from the db"
+  vpc_id      = aws_vpc.default_vpc.id
+
+  ingress {
+    description     = "Allow all traffic"
+    from_port       = "0"
+    to_port         = "0"
+    protocol        = "-1"
+    security_groups = [aws_security_group.db_allow_tcp.id]
+  }
+
+  egress {
+    description     = "Allow all traffic"
+    from_port       = "0"
+    to_port         = "0"
+    protocol        = "-1"
+    security_groups = [aws_security_group.db_allow_tcp.id]
   }
 }
 
@@ -41,7 +63,7 @@ resource "aws_instance" "bastion_host" {
   ami                         = data.aws_ami.ubuntu_ami.id
   instance_type               = "t2.micro"
   key_name                    = module.key_pair.key_pair_name
-  security_groups             = [aws_security_group.allow_ssh.id]
+  security_groups             = [aws_security_group.allow_ssh.id, aws_security_group.allow_db.id]
   associate_public_ip_address = true
 
   subnet_id = aws_subnet.public_subnet[count.index].id

--- a/.terraform/cognito.tf
+++ b/.terraform/cognito.tf
@@ -5,11 +5,19 @@ resource "aws_cognito_user_pool" "pool" {
   software_token_mfa_configuration {
     enabled = true
   }
+
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "aws_cognito_user_pool_domain" "main" {
   domain       = "greatnotes-security-levelup"
   user_pool_id = aws_cognito_user_pool.pool.id
+
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "aws_cognito_identity_provider" "google" {
@@ -47,6 +55,10 @@ resource "aws_cognito_user_pool_client" "api_client" {
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
   supported_identity_providers         = ["Google"]
+
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 resource "aws_cognito_user_pool_client" "api_client_local" {
@@ -61,6 +73,10 @@ resource "aws_cognito_user_pool_client" "api_client_local" {
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
   supported_identity_providers         = ["Google"]
+
+  lifecycle {
+    ignore_changes = all
+  }
 }
 
 data "aws_secretsmanager_secret_version" "google_oauth" {

--- a/.terraform/database.tf
+++ b/.terraform/database.tf
@@ -71,4 +71,8 @@ resource "aws_secretsmanager_secret_version" "rds_credentials" {
     "db_name"  : "${var.db_name}"
   }
   EOF
+
+  lifecycle {
+    ignore_changes = all
+  }
 }

--- a/.terraform/database.tf
+++ b/.terraform/database.tf
@@ -38,7 +38,8 @@ resource "random_password" "master_password" {
 }
 
 resource "aws_db_instance" "great_notes_db" {
-  identifier              = var.db_name
+  identifier              = var.instance_name
+  db_name                 = var.db_name
   username                = var.db_username
   password                = random_password.master_password.result
   allocated_storage       = 20
@@ -66,11 +67,8 @@ resource "aws_secretsmanager_secret_version" "rds_credentials" {
     "username" : "${var.db_username}",
     "password" : "${random_password.master_password.result}",
     "host"     : "${aws_db_instance.great_notes_db.endpoint}",
-    "port"     : "${aws_db_instance.great_notes_db.port}"
+    "port"     : "${aws_db_instance.great_notes_db.port}",
+    "db_name"  : "${var.db_name}"
   }
   EOF
-
-  lifecycle {
-    ignore_changes = all
-  }
 }

--- a/.terraform/database.tf
+++ b/.terraform/database.tf
@@ -5,19 +5,19 @@ resource "aws_security_group" "db_allow_tcp" {
   vpc_id      = aws_vpc.default_vpc.id
 
   ingress {
-    description     = "Allow all traffic from only ebs sg"
-    from_port       = "5432"
-    to_port         = "5432"
-    protocol        = "tcp"
-    security_groups = [aws_security_group.ebs_allow_tcp.id, aws_security_group.allow_ssh.id]
+    description = "Allow all traffic from ebs and bastion host"
+    from_port   = "5432"
+    to_port     = "5432"
+    protocol    = "tcp"
+    cidr_blocks = aws_subnet.public_subnet[*].cidr_block
   }
 
   egress {
-    description     = "Allow all traffic to only ebs sg"
-    from_port       = "5432"
-    to_port         = "5432"
-    protocol        = "tcp"
-    security_groups = [aws_security_group.ebs_allow_tcp.id, aws_security_group.allow_ssh.id]
+    description = "Allow all traffic to ebs and bastion host"
+    from_port   = "5432"
+    to_port     = "5432"
+    protocol    = "tcp"
+    cidr_blocks = aws_subnet.public_subnet[*].cidr_block
   }
 }
 
@@ -38,21 +38,21 @@ resource "random_password" "master_password" {
 }
 
 resource "aws_db_instance" "great_notes_db" {
-  identifier                  = var.db_name
-  username                    = var.db_username
-  password                    = random_password.master_password.result
-  allocated_storage           = 20
-  storage_type                = "gp2"
-  engine                      = "postgres"
-  engine_version              = "16.2"
-  instance_class              = "db.t3.micro"
-  db_subnet_group_name        = aws_db_subnet_group.db_subnet_group.name
-  vpc_security_group_ids      = [aws_security_group.db_allow_tcp.id]
-  maintenance_window          = "Mon:00:00-Mon:01:00"
-  publicly_accessible         = false
-  skip_final_snapshot         = true
-  multi_az                    = true
-  backup_retention_period     = 0
+  identifier              = var.db_name
+  username                = var.db_username
+  password                = random_password.master_password.result
+  allocated_storage       = 20
+  storage_type            = "gp2"
+  engine                  = "postgres"
+  engine_version          = "16.2"
+  instance_class          = "db.t3.micro"
+  db_subnet_group_name    = aws_db_subnet_group.db_subnet_group.name
+  vpc_security_group_ids  = [aws_security_group.db_allow_tcp.id]
+  maintenance_window      = "Mon:00:00-Mon:01:00"
+  publicly_accessible     = false
+  skip_final_snapshot     = true
+  multi_az                = true
+  backup_retention_period = 0
 }
 
 resource "aws_secretsmanager_secret" "rds_credentials" {

--- a/.terraform/ebs.tf
+++ b/.terraform/ebs.tf
@@ -267,7 +267,7 @@ resource "aws_elastic_beanstalk_environment" "great_notes_app_env" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = aws_security_group.ebs_allow_tcp.id
+    value     = "${aws_security_group.ebs_allow_tcp.id},${aws_security_group.allow_db.id}"
   }
 
   lifecycle {

--- a/.terraform/target_group.tf
+++ b/.terraform/target_group.tf
@@ -37,8 +37,7 @@ resource "aws_lb_target_group" "http-target-group8080" {
   }
 }
 
-resource "aws_lb_target_group_attachment" "instance" {
-  target_group_arn = aws_lb_target_group.http-target-group8080.arn
-  target_id        = var.ebs_instance_id
-  port             = 8080
+resource "aws_autoscaling_attachment" "default" {
+  autoscaling_group_name = aws_autoscaling_group.default.id
+  lb_target_group_arn   = aws_lb_target_group.http-target-group8080.arn
 }

--- a/.terraform/variables.tf
+++ b/.terraform/variables.tf
@@ -72,9 +72,3 @@ variable "domain_name" {
   description = "Domain name"
   type        = string
 }
-
-variable "ebs_instance_id" {
-  description = "ID of the ebs instance"
-  type        = string
-  sensitive   = true
-}

--- a/.terraform/variables.tf
+++ b/.terraform/variables.tf
@@ -9,6 +9,11 @@ variable "db_name" {
   description = "The name of the database"
 }
 
+variable "instance_name" {
+  type        = string
+  description = "The name of the database instance"
+}
+
 variable "vpc_name" {
   type        = string
   description = "The name of the VPC"


### PR DESCRIPTION
Terraform changes
- Added an autoscaling group attachment to the listener
- Modified RDS security groups to only allow elastic beanstalk and the bastion host to connect
- Modified bastion host security and elastic beanstalk groups to allow traffic from the RDS instance
- Changed terraform to create database in the RDS
- Added lifecycle blocks to ignore changes from terraform for already existing resources so as to keep the state of the infrastructure consistent

Workflow changes
- Changed flyway migration workflow to now create a tunnel to the RDS instance before running the migrations
- Removed aws credential secrets from the generated .env file in the deploy workflow